### PR TITLE
Fix in _get_matching_characters

### DIFF
--- a/pyjarowinkler/distance.py
+++ b/pyjarowinkler/distance.py
@@ -90,7 +90,7 @@ def _get_prefix(first, second):
 
 def _get_matching_characters(first, second):
     common = []
-    limit = math.floor(1 + (min(len(first), len(second)) / 2))
+    limit = math.floor(max(len(first), len(second)) / 2)
 
     for i, l in enumerate(first):
         left, right = int(max(0, i - limit)), int(min(i + limit + 1, len(second)))

--- a/pyjarowinkler/distance.py
+++ b/pyjarowinkler/distance.py
@@ -93,7 +93,7 @@ def _get_matching_characters(first, second):
     limit = math.floor(1 + (min(len(first), len(second)) / 2))
 
     for i, l in enumerate(first):
-        left, right = int(max(0, i - limit)), int(min(i + limit, len(second)))
+        left, right = int(max(0, i - limit)), int(min(i + limit + 1, len(second)))
         if l in second[left:right]:
             common.append(l)
             second = second[0:second.index(l)] + '*' + second[second.index(l) + 1:]


### PR DESCRIPTION
- The original code was biased towards the left side as a slice [i:j] does not contains the character at index j
- A limit of shorter/2 + 1 is used in StringUtils, this differs from Wikipedia and also Winkler's paper (http://www.amstat.org/sections/srms/Proceedings/papers/1990_056.pdf), where a distance of longer/2 - 1 is used, corresponding to positions of longer/2 as in the changed code. Changed code now correctly works with the "CTRATE" - "TRACE" example from wikipedia
